### PR TITLE
Fixed API 15 support; fixed lags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+## Version 1.1.1
+
+_2016-12-26_
+
+ * Fixed lags.
+ * Fixed API 15 support.
 
 ## Version 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the dependency
 
 ```groovy
 dependencies {
-    compile 'com.github.jetradarmobile:android-snowfall:1.1.0'
+    compile 'com.github.jetradarmobile:android-snowfall:1.1.1'
 }
 ```
 

--- a/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
+++ b/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
@@ -19,6 +19,9 @@ package com.jetradarmobile.snowfall
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.os.Handler
+import android.os.HandlerThread
+import android.support.v4.view.ViewCompat
 import android.util.AttributeSet
 import android.view.View
 import java.util.ArrayList
@@ -65,7 +68,11 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
     snowflakes = ArrayList(snowflakesNum)
 
     updateSnowflakesThread = UpdateSnowflakesThread()
-    updateSnowflakesThread.start()
+  }
+
+  private fun updateSnowflakes() {
+    updateSnowflakesThread.handler.post { snowflakes.forEach { it.update() } }
+    ViewCompat.postInvalidateOnAnimation(this)
   }
 
   private fun dpToPx(dp: Int): Int {
@@ -87,17 +94,14 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
     snowflakes.forEach { it.draw(canvas) }
+    updateSnowflakes()
   }
 
-  private inner class UpdateSnowflakesThread : Thread() {
-    private val FPS = 10L
+  private inner class UpdateSnowflakesThread() : HandlerThread("SnowflakesComputations") {
+    val handler by lazy { Handler(looper) }
 
-    override fun run() {
-      while (true) {
-        try { Thread.sleep(FPS) } catch (ignored: InterruptedException) {}
-        snowflakes.forEach { it.update() }
-        postInvalidateOnAnimation()
-      }
+    init {
+      start()
     }
   }
 }


### PR DESCRIPTION
This pull request fixes:
* `postInvalidateOnAnimation()` only available from API 16
* tiny lags because of ignoring system `Choreographer`