### PR TITLE
Add ability to stop snowfall without making it disappear

### DIFF
--- a/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
+++ b/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
@@ -92,8 +92,22 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
     if (isInEditMode) {
       return
     }
-    snowflakes?.forEach { it.draw(canvas) }
-    updateSnowflakes()
+    val fallingSnowflakes = snowflakes?.filter { it.isStillFalling() }
+    if (fallingSnowflakes?.isNotEmpty() == true) {
+      fallingSnowflakes.forEach { it.draw(canvas) }
+      updateSnowflakes()
+    }
+    else {
+      visibility = GONE
+    }
+  }
+
+  fun stopFalling() {
+    snowflakes?.forEach { it.shouldRecycleFalling = false }
+  }
+
+  fun restartFalling() {
+    snowflakes?.forEach { it.shouldRecycleFalling = true }
   }
 
   private fun createSnowflakes(): Array<Snowflake> {
@@ -114,9 +128,12 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
   }
 
   private fun updateSnowflakes() {
-    updateSnowflakesThread.handler.post {
-      snowflakes?.forEach { it.update() }
-      postInvalidateOnAnimation()
+    val fallingSnowflakes = snowflakes?.filter { it.isStillFalling() }
+    if (fallingSnowflakes?.isNotEmpty() == true) {
+      updateSnowflakesThread.handler.post {
+        fallingSnowflakes.forEach { it.update() }
+        postInvalidateOnAnimation()
+      }
     }
   }
 


### PR DESCRIPTION
Previously, the only way to stop the snowfall was to make the
SnowfallView GONE, meaning that the snow would immediately disappear.
With this change, one can stop the snowfall, but any snowflakes
that are already visible on the screen will continue falling.

This functionality was added for use within the Expedia app in December 2017.
![ezgif-4-d8771ec81e](https://user-images.githubusercontent.com/1413600/33854641-72834e54-de90-11e7-8c7a-05e0f4828b26.gif)
