### PR TITLE
Fix memory leak related to inner HandlerThread

### DIFF
--- a/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
+++ b/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
@@ -48,7 +48,7 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
   private val snowflakesFadingEnabled: Boolean
   private val snowflakesAlreadyFalling: Boolean
 
-  private val updateSnowflakesThread: UpdateSnowflakesThread
+  private lateinit var updateSnowflakesThread: UpdateSnowflakesThread
   private var snowflakes: Array<Snowflake>? = null
 
   init {
@@ -68,7 +68,17 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
     } finally {
       a.recycle()
     }
+
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
     updateSnowflakesThread = UpdateSnowflakesThread()
+  }
+
+  override fun onDetachedFromWindow() {
+    updateSnowflakesThread.quit()
+    super.onDetachedFromWindow()
   }
 
   private fun dpToPx(dp: Int): Int {
@@ -120,7 +130,7 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
     }
   }
 
-  private inner class UpdateSnowflakesThread : HandlerThread("SnowflakesComputations") {
+  private class UpdateSnowflakesThread : HandlerThread("SnowflakesComputations") {
     val handler by lazy { Handler(looper) }
 
     init {


### PR DESCRIPTION
We were using this library and noticed that it would leak the activity that contains the `SnowfallView`. This was due to the HandlerThread being an `inner` class, therefore having a reference to the view. 

I also ensured that the thread is not started until the view is attached. And that we call `quit()` when detached. 

I tested the changes with the sample app and the android studio memory analyser.