### PR TITLE
Setting visibility to visible when invoking restartFalling

### DIFF
--- a/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
+++ b/snowfall/src/main/java/com/jetradarmobile/snowfall/SnowfallView.kt
@@ -118,6 +118,7 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
 
   fun restartFalling() {
     snowflakes?.forEach { it.shouldRecycleFalling = true }
+    visibility = VISIBLE
   }
 
   private fun createSnowflakes(): Array<Snowflake> {
@@ -134,7 +135,7 @@ class SnowfallView(context: Context, attrs: AttributeSet) : View(context, attrs)
         speedMax = snowflakeSpeedMax,
         fadingEnabled = snowflakesFadingEnabled,
         alreadyFalling = snowflakesAlreadyFalling)
-    return Array(snowflakesNum, { Snowflake(snowflakeParams) })
+    return Array(snowflakesNum) { Snowflake(snowflakeParams) }
   }
 
   private fun updateSnowflakes() {

--- a/snowfall/src/main/java/com/jetradarmobile/snowfall/Snowflake.kt
+++ b/snowfall/src/main/java/com/jetradarmobile/snowfall/Snowflake.kt
@@ -43,7 +43,7 @@ internal class Snowflake(val params: Params) {
   private val randomizer by lazy { Randomizer() }
 
   var shouldRecycleFalling = true
-  private var stopped = false;
+  private var stopped = false
 
   init {
     reset()
@@ -93,7 +93,7 @@ internal class Snowflake(val params: Params) {
         }
       } else {
         positionY = params.parentHeight + size.toDouble()
-        stopped = true;
+        stopped = true
       }
     }
     if (params.fadingEnabled) {


### PR DESCRIPTION
If I invoke stopFalling() on SnowfallView and wait for all snowflakes to fall out of view, calling restartFalling() does not render the snowflakes unless I set the visibility back to VISIBLE. 

Ideally this should be taken care of in restartFalling().

Also cleaned up a few lint warnings. 